### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+jreen (1.2.0-3) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 11:06:52 +0100
+
 jreen (1.2.0-2) unstable; urgency=medium
 
   * Add jreen-qt56.patch to fix build error with Qt 5.6. (Closes: #827585)

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Build-Depends: cmake,
                libjdns-dev
 Standards-Version: 3.9.8
 Homepage: https://qutim.org/jreen
-Vcs-Git: git://github.com/justin-time/libjreen.git
+Vcs-Git: https://github.com/justin-time/libjreen.git
 Vcs-Browser: https://github.com/justin-time/libjreen
 
 Package: libjreen1


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
